### PR TITLE
Update pandoc_tex_numbering.py

### DIFF
--- a/src/pandoc_tex_numbering/pandoc_tex_numbering.py
+++ b/src/pandoc_tex_numbering/pandoc_tex_numbering.py
@@ -88,7 +88,7 @@ def prepare(doc):
         r"\\begin\{("+"|".join(doc.pandoc_tex_numbering["multiline_envs"])+")}"
     )
 
-    max_levels = doc.get_metadata("section-max-levels", 10)
+    max_levels = int(doc.get_metadata("section-max-levels", 10))
     # From here, we start to build the core formater system for numbering
     aka = {
         "fig": "figure",


### PR DESCRIPTION
Great Repo! Thanks for your work!

This PR aims to fix an error when setting `section-max-levels=[number]`. 

> ./pandoc/pandoc-3.5/pandoc.exe chapter5.tex -o chapter5-converted.docx -w docx --filter pandoc-tex-numbering **--metadata section-max-levels=4** --bibliography=chapter5.bib --bibliography=steam_vm.bib --citeproc --csl "./pandoc/apa.csl" --reference-doc="./pandoc/Museum-v2-temp.docx"

Error:

```
  File "xxxxxxxxxxxxxxxxxxxxxxxxx\site-packages\pandoc_tex_numbering\pandoc_tex_numbering.py", line 136, in prepare
    for i in range(1,max_levels+1):
TypeError: can only concatenate str (not "int") to str
Error running filter pandoc-tex-numbering:
Filter returned error status 1
```

Now it should work with both `section-max-levels=4` and `section-max-levels="4"` :)


