### PR TITLE
bug with section label refernces

### DIFF
--- a/src/pandoc_tex_numbering/pandoc_tex_numbering.py
+++ b/src/pandoc_tex_numbering/pandoc_tex_numbering.py
@@ -384,15 +384,21 @@ def find_labels_header(elem,doc):
     # Skip numbering if level exceeds max_levels
     max_levels = int(doc.get_metadata("section-max-levels", 10))
     if this_level > max_levels:
-        logger.info(f"Skipping numbering for section level {this_level} (exceeds max_levels={max_levels})")
         return
         
     doc.num_state.next_sec(level=this_level)
     num_obj = doc.num_state.current_sec(level=this_level)
+    
+    # Check for identifier
+    if elem.identifier:
+        label = elem.identifier
+        doc.ref_dict[label] = num_obj
+    
+
     for child in elem.content:
         if isinstance(child,Span) and "label" in child.attributes:
             label = child.attributes["label"]
-            doc.ref_dict[label] = num_obj
+            doc.ref_dict[label] = num_obj    
     if doc.settings["num_sec"]:
         elem.content.insert(0,Space())
         elem.content.insert(0,Str(num_obj.src))


### PR DESCRIPTION
In the example below only the table would be correctly referenced, not the sections.
The issue was that `find_labels_header` only checked for labels in Span children but ignored the Header element's identifier where pandoc stores `\label{}` content.

```latex
\documentclass{article}
\begin{document}

\section{Introduction}\label{sec:intro}

This document demonstrates section and table referencing. The methodology is described in Section~\ref{sec:methods}.

\section{Methodology}\label{sec:methods}

The parameters are shown in Table~\ref{tab:parameters}. This builds on Section~\ref{sec:intro}.

\begin{table}[h]
\centering
\begin{tabular}{|l|c|}
\hline
Parameter & Value \\
\hline
Sample Size & 100 \\
Temperature & 25°C \\
\hline
\end{tabular}
\caption{Experimental parameters}
\label{tab:parameters}
\end{table}

\section{Results}\label{sec:results}

Table~\ref{tab:parameters} shows the key findings from Section~\ref{sec:methods}.

\end{document}
```